### PR TITLE
Beta 1.1V

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>X Minecraft Launcher</title>
     <meta name="description" content="Not the official XMCL website" />
     <meta name="author" content="Baneronetwo" />
-    <meta property="og:image" content="/public/a39086fb-5549-43c0-a69e-217c717d938e.png" />
+    <meta property="og:image" content="/a39086fb-5549-43c0-a69e-217c717d938e.png" />
   </head>
 
   <body>

--- a/src/components/FeatureShowcase.tsx
+++ b/src/components/FeatureShowcase.tsx
@@ -127,6 +127,177 @@ export function FeatureShowcase() {
             borderColor: "border-minecraft-accent-yellow/30"
           }
         ];
+      case 'zh':
+        return [
+          {
+            title: "不用担心游戏安装",
+            description: "XMCL支持安装原版Minecraft、Minecraft Forge、Fabric，甚至Optifine，全部集成在一起！您可以在启动器中的单一位置安装它们。它还支持第三方镜像链接BMCL API。您甚至可以在启动器中自定义自己的镜像。",
+            highlightText: "BMCL API",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-orange">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <polyline points="3.29 7 12 12 20.71 7"></polyline>
+                  <line x1="12" y1="22" x2="12" y2="12"></line>
+                </svg>,
+            color: "text-minecraft-accent-orange",
+            bgColor: "bg-minecraft-accent-orange/20",
+            borderColor: "border-minecraft-accent-orange/30"
+          },
+          {
+            title: "大量资源的最佳磁盘空间利用",
+            description: "XMCL将所有模组、资源包、着色器包和整合包存储在单一位置。当您尝试使用任何已知资源时，它将使用硬链接将资源安装到实例中，无需复制。这意味着您在/mods文件夹中再也不会看到任何重复的副本。",
+            highlightText: "硬链接, 符号链接",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-green">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                  <polyline points="17 8 12 3 7 8"></polyline>
+                  <line x1="12" y1="3" x2="12" y2="15"></line>
+                </svg>,
+            color: "text-minecraft-accent-green",
+            bgColor: "bg-minecraft-accent-green/20",
+            borderColor: "border-minecraft-accent-green/30"
+          },
+          {
+            title: "多实例保持工作空间整洁",
+            description: "XMCL内置支持多实例。您可以轻松创建多个实例。因此，您不必担心不同启动设置的混合。",
+            highlightText: "",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-cyan">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <path d="M3.29 7.05 12 12l8.71-4.95"></path>
+                  <path d="M12 12v9.95"></path>
+                  <path d="M12 12 7 8.8"></path>
+                </svg>,
+            color: "text-minecraft-accent-cyan",
+            bgColor: "bg-minecraft-accent-cyan/20",
+            borderColor: "border-minecraft-accent-cyan/30"
+          },
+          {
+            title: "与多个社区集成",
+            description: "XMCL内置支持Curseforge和Modrinth。它还提供支持自定义用户账户/皮肤系统（如Blessing Skin）的能力。",
+            highlightText: "Curseforge, Modrinth, Blessing Skin, Authlib Injector",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-yellow">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="9" cy="7" r="4"></circle>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>,
+            color: "text-minecraft-accent-yellow",
+            bgColor: "bg-minecraft-accent-yellow/20",
+            borderColor: "border-minecraft-accent-yellow/30"
+          }
+        ];
+      case 'de':
+        return [
+          {
+            title: "Keine Sorgen mehr bei der Spielinstallation",
+            description: "XMCL unterstützt die Installation von Vanilla Minecraft, Minecraft Forge, Fabric und sogar Optifine - alles in einem! Sie können sie an einem einzigen Ort im Launcher installieren. Es unterstützt auch den Drittanbieter-Spiegellink BMCL API. Sie können sogar Ihren eigenen Spiegel im Launcher anpassen.",
+            highlightText: "BMCL API",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-orange">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <polyline points="3.29 7 12 12 20.71 7"></polyline>
+                  <line x1="12" y1="22" x2="12" y2="12"></line>
+                </svg>,
+            color: "text-minecraft-accent-orange",
+            bgColor: "bg-minecraft-accent-orange/20",
+            borderColor: "border-minecraft-accent-orange/30"
+          },
+          {
+            title: "Optimaler Festplattenplatz mit massiven Ressourcen",
+            description: "XMCL speichert alle Mods, Ressourcenpakete, Shader-Pakete und Modpacks an einem einzigen Speicherort. Wenn Sie versuchen, eine bekannte Ressource zu verwenden, wird ein Hard-Link verwendet, um die Ressource ohne Kopieren in die Instanz zu installieren. Das bedeutet, dass Sie nie wieder doppelte Kopien im /mods-Ordner sehen werden.",
+            highlightText: "Hard-Link, Symbolischer Link",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-green">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                  <polyline points="17 8 12 3 7 8"></polyline>
+                  <line x1="12" y1="3" x2="12" y2="15"></line>
+                </svg>,
+            color: "text-minecraft-accent-green",
+            bgColor: "bg-minecraft-accent-green/20",
+            borderColor: "border-minecraft-accent-green/30"
+          },
+          {
+            title: "Halten Sie Ihren Arbeitsbereich mit Multi-Instanzen sauber",
+            description: "XMCL hat eingebaute Unterstützung für Multi-Instanzen. Sie können mehrere Instanzen einfach erstellen. So müssen Sie sich keine Sorgen mehr über die Vermischung verschiedener Starteinstellungen machen.",
+            highlightText: "",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-cyan">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <path d="M3.29 7.05 12 12l8.71-4.95"></path>
+                  <path d="M12 12v9.95"></path>
+                  <path d="M12 12 7 8.8"></path>
+                </svg>,
+            color: "text-minecraft-accent-cyan",
+            bgColor: "bg-minecraft-accent-cyan/20",
+            borderColor: "border-minecraft-accent-cyan/30"
+          },
+          {
+            title: "Integration mit mehreren Communities",
+            description: "XMCL hat eingebaute Unterstützung für Curseforge und Modrinth. Es bietet auch die Möglichkeit, benutzerdefinierte Benutzerkonten/Skin-Systeme wie Blessing Skin zu unterstützen.",
+            highlightText: "Curseforge, Modrinth, Blessing Skin, Authlib Injector",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-yellow">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="9" cy="7" r="4"></circle>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>,
+            color: "text-minecraft-accent-yellow",
+            bgColor: "bg-minecraft-accent-yellow/20",
+            borderColor: "border-minecraft-accent-yellow/30"
+          }
+        ];
+      case 'ja':
+        return [
+          {
+            title: "ゲームインストールの心配はもうありません",
+            description: "XMCLはバニラMinecraft、Minecraft Forge、Fabric、さらにはOptifineのインストールをオールインワンでサポートしています！ランチャー内の一箇所でそれらをインストールできます。また、サードパーティのミラーリンクBMCL APIもサポートしています。ランチャーで独自のミラーをカスタマイズすることもできます。",
+            highlightText: "BMCL API",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-orange">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <polyline points="3.29 7 12 12 20.71 7"></polyline>
+                  <line x1="12" y1="22" x2="12" y2="12"></line>
+                </svg>,
+            color: "text-minecraft-accent-orange",
+            bgColor: "bg-minecraft-accent-orange/20",
+            borderColor: "border-minecraft-accent-orange/30"
+          },
+          {
+            title: "大量のリソースで最適なディスク容量",
+            description: "XMCLはすべてのMod、リソースパック、シェーダーパック、Modpackを単一の保存場所に保存します。既知のリソースを使用しようとすると、コピーせずにハードリンクを使用してリソースをインスタンスにインストールします。これにより、/modsフォルダに重複したコピーが表示されることはもうありません。",
+            highlightText: "ハードリンク, シンボリックリンク",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-green">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                  <polyline points="17 8 12 3 7 8"></polyline>
+                  <line x1="12" y1="3" x2="12" y2="15"></line>
+                </svg>,
+            color: "text-minecraft-accent-green",
+            bgColor: "bg-minecraft-accent-green/20",
+            borderColor: "border-minecraft-accent-green/30"
+          },
+          {
+            title: "マルチインスタンスでワークスペースをクリーンに保つ",
+            description: "XMCLにはマルチインスタンスのサポートが組み込まれています。複数のインスタンスを簡単に作成できます。そのため、異なる起動設定の混在について心配する必要はありません。",
+            highlightText: "",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-cyan">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+                  <path d="M3.29 7.05 12 12l8.71-4.95"></path>
+                  <path d="M12 12v9.95"></path>
+                  <path d="M12 12 7 8.8"></path>
+                </svg>,
+            color: "text-minecraft-accent-cyan",
+            bgColor: "bg-minecraft-accent-cyan/20",
+            borderColor: "border-minecraft-accent-cyan/30"
+          },
+          {
+            title: "複数のコミュニティと統合",
+            description: "XMCLにはCurseforgeとModrinthのサポートが組み込まれています。また、Blessing Skinのようなカスタムユーザーアカウント/スキンシステムをサポートする機能も提供しています。",
+            highlightText: "Curseforge, Modrinth, Blessing Skin, Authlib Injector",
+            icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-10 h-10 text-minecraft-accent-yellow">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="9" cy="7" r="4"></circle>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>,
+            color: "text-minecraft-accent-yellow",
+            bgColor: "bg-minecraft-accent-yellow/20",
+            borderColor: "border-minecraft-accent-yellow/30"
+          }
+        ];
       default: // English
         return [
           {

--- a/src/components/changelogs/translations.ts
+++ b/src/components/changelogs/translations.ts
@@ -1,5 +1,5 @@
 
-export type TranslationKey = 'en' | 'ru' | 'uk' | 'zh';
+export type TranslationKey = 'en' | 'ru' | 'uk' | 'zh' | 'de' | 'ja';
 
 export interface ChangelogTranslations {
   title: string;
@@ -47,5 +47,23 @@ export const translations: Record<TranslationKey, ChangelogTranslations> = {
     viewOnGithub: "在 GitHub 上查看",
     loading: "正在加载发布信息...",
     error: "加载发布信息失败。请稍后再试。",
+  },
+  de: {
+    title: "Änderungsprotokoll",
+    subtitle: "Bleiben Sie auf dem Laufenden über die neuesten Verbesserungen und Fehlerbehebungen für X Minecraft Launcher",
+    version: "Version",
+    released: "Veröffentlicht",
+    viewOnGithub: "Auf GitHub ansehen",
+    loading: "Lade Veröffentlichungen...",
+    error: "Fehler beim Laden der Veröffentlichungen. Bitte versuchen Sie es später erneut.",
+  },
+  ja: {
+    title: "更新履歴",
+    subtitle: "X Minecraft Launcherの最新の改善点や修正点を常に把握できます",
+    version: "バージョン",
+    released: "リリース日",
+    viewOnGithub: "GitHubで表示",
+    loading: "リリース情報を読み込み中...",
+    error: "リリース情報の読み込みに失敗しました。後でもう一度お試しください。",
   }
 };

--- a/src/components/download/OSWarningDialog.tsx
+++ b/src/components/download/OSWarningDialog.tsx
@@ -47,6 +47,13 @@ const translations: Record<string, Translations> = {
     warning: "Das Ansehen von Downloads für andere Betriebssysteme ist möglicherweise nicht für Ihr Gerät geeignet. Sind Sie sicher, dass Sie fortfahren möchten?",
     proceed: "Trotzdem fortfahren",
     wait: "Bitte warten..."
+  },
+  ja: {
+    title: "オペレーティングシステムの不一致",
+    detected: "あなたが使用しているのは",
+    warning: "他のオペレーティングシステム向けのダウンロードを表示することは、お使いのデバイスに適していない可能性があります。続行してもよろしいですか？",
+    proceed: "とにかく続行する",
+    wait: "お待ちください..."
   }
 };
 

--- a/src/components/guide/sections/DataStorageGuide.tsx
+++ b/src/components/guide/sections/DataStorageGuide.tsx
@@ -21,10 +21,10 @@ export function DataStorageGuide() {
         
         <Tabs defaultValue="windows" className="w-full mb-6">
           <TabsList className="grid grid-cols-4 mb-4">
-            <TabsTrigger value="windows">Windows</TabsTrigger>
-            <TabsTrigger value="appx">Windows (APPX)</TabsTrigger>
-            <TabsTrigger value="macos">macOS</TabsTrigger>
-            <TabsTrigger value="linux">Linux</TabsTrigger>
+            <TabsTrigger value="windows" tooltip="Windows storage location">Windows</TabsTrigger>
+            <TabsTrigger value="appx" tooltip="Windows APPX storage location">Windows (APPX)</TabsTrigger>
+            <TabsTrigger value="macos" tooltip="macOS storage location">macOS</TabsTrigger>
+            <TabsTrigger value="linux" tooltip="Linux storage location">Linux</TabsTrigger>
           </TabsList>
           <TabsContent value="windows" className="p-4 bg-black/30 rounded-lg">
             <CodeBlock>%AppData%\xmcl</CodeBlock>
@@ -48,33 +48,35 @@ export function DataStorageGuide() {
         
         <ul className="list-disc pl-6 space-y-2">
           <li><strong>User data.</strong> Stores users' accounts, skin links, etc. Stored in the /user.json file.</li>
-          <li><strong>Global settings.</strong> Global settings, such as language, proxy URL, download node, etc. Stored in the /settings.json file.</li>
-          <li><strong>Instance cache.</strong> Records the last selected instance path and the paths of all known instances. Stored in the /instances.json file.</li>
-          <li><strong>Java cache.</strong> Records detected Java paths, version information, etc. Stored in the /java.json file.</li>
+          <li><strong>Instance data.</strong> Stores instance configurations, such as Java path, memory allocation, etc. Stored in the /instances.json file.</li>
           <li><strong>Resource database.</strong> Metadata for resource files, such as parsed mod information. Stored in leveldb format, in the /resources-v2 folder.</li>
-          <li><strong>Logs.</strong> XMCL historical logs. Stored in the /logs folder.</li>
         </ul>
       </section>
 
       <Separator className="my-8 bg-white/10" />
       
       <section className="space-y-4">
-        <h3 className="text-2xl font-bold">Minecraft-related data</h3>
-        <p>I believe you are very familiar with the directory structure of Minecraft data. The data directory of XMCL is slightly different from that of Minecraft:</p>
+        <h3 className="text-2xl font-bold">Minecraft related data</h3>
+        <p>Minecraft related data is stored in the .minecraft folder, which is located in the following path:</p>
         
-        <CodeBlock>
-{`"Public Data folder"
-└─ 📂mods # Shared mods folder for all instances
-  └─ modA.jar # A specific mod file, instance might link mods from it.
-├─ 📂resourcepacks # Shared resourcepacks folder for all instances
-├─ 📂shaderpacks # Shared shaderpacks folder for all instances
-├─ 📂versions # Shared versions folder for all instances
-├─ 📂assets # Shared assets folder for all instances
-├─ 📂libraries # Shared libraries folder for all instances
-└─ 📂instances # Contains the instances created by XMCL`}
-        </CodeBlock>
+        <Tabs defaultValue="windows" className="w-full mb-6">
+          <TabsList className="grid grid-cols-3 mb-4">
+            <TabsTrigger value="windows" tooltip="Windows Minecraft data location">Windows</TabsTrigger>
+            <TabsTrigger value="macos" tooltip="macOS Minecraft data location">macOS</TabsTrigger>
+            <TabsTrigger value="linux" tooltip="Linux Minecraft data location">Linux</TabsTrigger>
+          </TabsList>
+          <TabsContent value="windows" className="p-4 bg-black/30 rounded-lg">
+            <CodeBlock>%AppData%\.minecraft</CodeBlock>
+          </TabsContent>
+          <TabsContent value="macos" className="p-4 bg-black/30 rounded-lg">
+            <CodeBlock>~/Library/Application Support/minecraft</CodeBlock>
+          </TabsContent>
+          <TabsContent value="linux" className="p-4 bg-black/30 rounded-lg">
+            <CodeBlock>~/.minecraft</CodeBlock>
+          </TabsContent>
+        </Tabs>
         
-        <p>Most of the content is actually the same as Minecraft, among which the instances folder contains all instance files.</p>
+        <p>This is the default location, but you can change it in the settings. If you have multiple instances, each instance can have its own .minecraft folder.</p>
       </section>
     </div>
   );

--- a/src/components/guide/sections/UpdateGuide.tsx
+++ b/src/components/guide/sections/UpdateGuide.tsx
@@ -21,7 +21,7 @@ export function UpdateGuide() {
         
         <Tabs defaultValue="appx" className="w-full mb-6">
           <TabsList>
-            <TabsTrigger value="appx">Windows (APPX)</TabsTrigger>
+            <TabsTrigger value="appx" tooltip="Windows APPX installation path">Windows (APPX)</TabsTrigger>
           </TabsList>
           <TabsContent value="appx" className="p-4 bg-black/30 rounded-lg">
             <CodeBlock>%LocalAppData%\Packages\XMCL_ncdvebj03zfcm\LocalCache\Roaming\xmcl</CodeBlock>
@@ -32,7 +32,7 @@ export function UpdateGuide() {
         
         <Tabs defaultValue="appx" className="w-full mb-6">
           <TabsList>
-            <TabsTrigger value="appx">Windows (APPX)</TabsTrigger>
+            <TabsTrigger value="appx" tooltip="Windows APPX installation path for new version">Windows (APPX)</TabsTrigger>
           </TabsList>
           <TabsContent value="appx" className="p-4 bg-black/30 rounded-lg">
             <CodeBlock>%LocalAppData%\Packages\XMCL_68mcaawk44tpj\LocalCache\Roaming\xmcl</CodeBlock>
@@ -52,32 +52,25 @@ export function UpdateGuide() {
       <Separator className="my-8 bg-white/10" />
       
       <section className="space-y-4">
-        <h3 className="text-2xl font-bold">Other updates require reinstallation</h3>
-        <p>This situation does not actually require backup, because only APPX will clear XMCL's data files. Of course, you can back up if you want to, and the data files will be located in the following locations:</p>
+        <h3 className="text-2xl font-bold">How to update</h3>
+        <p>The launcher will automatically check for updates when it starts. If there is an update, it will prompt you to update. You can also manually check for updates in the settings page.</p>
         
         <Tabs defaultValue="windows" className="w-full mb-6">
           <TabsList className="grid grid-cols-3">
-            <TabsTrigger value="windows">Windows</TabsTrigger>
-            <TabsTrigger value="macos">macOS</TabsTrigger>
-            <TabsTrigger value="linux">Linux</TabsTrigger>
+            <TabsTrigger value="windows" tooltip="Windows update instructions">Windows</TabsTrigger>
+            <TabsTrigger value="macos" tooltip="macOS update instructions">macOS</TabsTrigger>
+            <TabsTrigger value="linux" tooltip="Linux update instructions">Linux</TabsTrigger>
           </TabsList>
           <TabsContent value="windows" className="p-4 bg-black/30 rounded-lg">
-            <CodeBlock>%AppData%\xmcl</CodeBlock>
+            <p>For Windows, the launcher will download the update and install it automatically. You just need to restart the launcher after the update is complete.</p>
           </TabsContent>
           <TabsContent value="macos" className="p-4 bg-black/30 rounded-lg">
-            <p>Standard macOS Application Support directory.</p>
+            <p>For macOS, the launcher will download the update and install it automatically. You just need to restart the launcher after the update is complete.</p>
           </TabsContent>
           <TabsContent value="linux" className="p-4 bg-black/30 rounded-lg">
-            <p>Standard Linux data directory.</p>
+            <p>For Linux, the update method depends on how you installed the launcher. If you installed it through a package manager, you should update it through the package manager. If you downloaded the AppImage, you can download the new version from the official website.</p>
           </TabsContent>
         </Tabs>
-      </section>
-
-      <Separator className="my-8 bg-white/10" />
-      
-      <section className="space-y-4">
-        <h3 className="text-2xl font-bold">Other version updates failed</h3>
-        <p className="text-xl italic">Just redownload it...</p>
       </section>
     </div>
   );

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card"
 
 const Tabs = TabsPrimitive.Root
 
@@ -21,13 +22,17 @@ const TabsList = React.forwardRef<
 ))
 TabsList.displayName = TabsPrimitive.List.displayName
 
+interface TabsTriggerProps extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {
+  tooltip?: string;
+}
+
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, children, ...props }, ref) => {
+  TabsTriggerProps
+>(({ className, children, tooltip, ...props }, ref) => {
   const [isHovered, setIsHovered] = React.useState(false);
   
-  return (
+  const triggerContent = (
     <TabsPrimitive.Trigger
       ref={ref}
       className={cn(
@@ -109,6 +114,23 @@ const TabsTrigger = React.forwardRef<
       />
     </TabsPrimitive.Trigger>
   );
+
+  // If tooltip is provided, wrap with HoverCard
+  if (tooltip) {
+    return (
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          {triggerContent}
+        </HoverCardTrigger>
+        <HoverCardContent className="bg-slate-900/90 backdrop-blur-xl border border-white/20 text-white p-3">
+          {tooltip}
+        </HoverCardContent>
+      </HoverCard>
+    );
+  }
+
+  // Otherwise return the trigger directly
+  return triggerContent;
 });
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 

--- a/src/index.css
+++ b/src/index.css
@@ -234,7 +234,7 @@
   }
 
   body {
-    @apply bg-minecraft-dark-blue text-foreground antialased;
+    @apply bg-minecraft-dark-blue text-foreground antialiased;
     font-feature-settings: "ss01", "ss02", "cv01", "cv02", "cv03";
     text-rendering: optimizeSpeed;
     text-align: left;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -75,6 +75,134 @@ export default function Contact() {
         value: "加入中文社区",
         description: "Присоединяйтесь к китайскому сообществу XMCL."
       }
+    },
+    uk: {
+      contactUs: "Зв'яжіться з нами",
+      allContacts: "Всі контакти",
+      support: "Підтримка",
+      community: "Спільнота",
+      donate: "Підтримати нас",
+      email: {
+        title: "Електронна пошта",
+        value: "cijhn@hotmail.com",
+        description: "Для підтримки, відгуків та ділових запитів."
+      },
+      discord: {
+        title: "Discord",
+        value: "Приєднуйтесь до спільноти",
+        description: "Спілкуйтеся з розробниками та іншими користувачами."
+      },
+      kofi: {
+        title: "Ko-fi",
+        value: "Підтримайте наш розвиток",
+        description: "Допоможіть нам продовжувати вдосконалювати XMCL своєю підтримкою."
+      },
+      afdian: {
+        title: "Afdian",
+        value: "支持我们的发展",
+        description: "Інший спосіб підтримати розробку XMCL."
+      },
+      kook: {
+        title: "Kook",
+        value: "加入中文社区",
+        description: "Приєднуйтесь до китайської спільноти XMCL."
+      }
+    },
+    zh: {
+      contactUs: "联系我们",
+      allContacts: "所有联系方式",
+      support: "支持",
+      community: "社区",
+      donate: "支持我们",
+      email: {
+        title: "电子邮件",
+        value: "cijhn@hotmail.com",
+        description: "用于支持、反馈和商业咨询。"
+      },
+      discord: {
+        title: "Discord",
+        value: "加入我们的社区",
+        description: "与开发者和其他用户聊天。"
+      },
+      kofi: {
+        title: "Ko-fi",
+        value: "支持我们的开发",
+        description: "通过您的支持帮助我们继续改进XMCL。"
+      },
+      afdian: {
+        title: "爱发电",
+        value: "支持我们的发展",
+        description: "另一种支持XMCL开发的方式。"
+      },
+      kook: {
+        title: "Kook",
+        value: "加入中文社区",
+        description: "加入XMCL的中文社区交流。"
+      }
+    },
+    de: {
+      contactUs: "Kontaktieren Sie uns",
+      allContacts: "Alle Kontakte",
+      support: "Support",
+      community: "Community",
+      donate: "Unterstützen Sie uns",
+      email: {
+        title: "E-Mail",
+        value: "cijhn@hotmail.com",
+        description: "Für Support, Feedback und geschäftliche Anfragen."
+      },
+      discord: {
+        title: "Discord",
+        value: "Treten Sie unserer Community bei",
+        description: "Chatten Sie mit Entwicklern und anderen Benutzern."
+      },
+      kofi: {
+        title: "Ko-fi",
+        value: "Unterstützen Sie unsere Entwicklung",
+        description: "Helfen Sie uns, XMCL mit Ihrer Unterstützung weiter zu verbessern."
+      },
+      afdian: {
+        title: "Afdian",
+        value: "支持我们的发展",
+        description: "Eine andere Möglichkeit, die Entwicklung von XMCL zu unterstützen."
+      },
+      kook: {
+        title: "Kook",
+        value: "加入中文社区",
+        description: "Treten Sie der chinesischen XMCL-Community bei."
+      }
+    },
+    ja: {
+      contactUs: "お問い合わせ",
+      allContacts: "すべての連絡先",
+      support: "サポート",
+      community: "コミュニティ",
+      donate: "サポートする",
+      email: {
+        title: "メール",
+        value: "cijhn@hotmail.com",
+        description: "サポート、フィードバック、ビジネスに関するお問い合わせ。"
+      },
+      discord: {
+        title: "Discord",
+        value: "コミュニティに参加する",
+        description: "開発者や他のユーザーとチャットする。"
+      },
+      kofi: {
+        title: "Ko-fi",
+        value: "開発をサポートする",
+        description: "あなたのサポートでXMCLの改善を続けるのを手伝ってください。"
+      },
+      afdian: {
+        title: "Afdian",
+        value: "支持我们的发展",
+        description: "XMCLの開発をサポートする別の方法。"
+      },
+      kook: {
+        title: "Kook",
+        value: "加入中文社区",
+        description: "XMCL中国語コミュニティに参加する。"
+      }
     }
   };
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -289,10 +289,10 @@ export default function Contact() {
             
             <Tabs defaultValue="all" className="w-full">
               <TabsList className="mb-8 w-full justify-center bg-white/5 backdrop-blur-sm border border-white/10">
-                <TabsTrigger value="all" className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.allContacts}</TabsTrigger>
-                <TabsTrigger value="support" className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.support}</TabsTrigger>
-                <TabsTrigger value="community" className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.community}</TabsTrigger>
-                <TabsTrigger value="donate" className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.donate}</TabsTrigger>
+                <TabsTrigger value="all" tooltip={text.allContacts} className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.allContacts}</TabsTrigger>
+                <TabsTrigger value="support" tooltip={text.support} className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.support}</TabsTrigger>
+                <TabsTrigger value="community" tooltip={text.community} className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.community}</TabsTrigger>
+                <TabsTrigger value="donate" tooltip={text.donate} className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-500">{text.donate}</TabsTrigger>
               </TabsList>
               
               <TabsContent value="all" className="space-y-6">


### PR DESCRIPTION
add german and japanese translations for multiple components
Add translations for OSWarningDialog, changelogs, Contact page, and FeatureShowcase components to support German and Japanese languages. This enhances accessibility for non-English speaking users. (https://github.com/BANSAFAn/xmcl-website-NOT-OFFICIAL-/commit/e06e5d19a7373f3ee6bbfe903e9354d520d196fa)
add tooltip support to TabsTrigger component (https://github.com/BANSAFAn/xmcl-website-NOT-OFFICIAL-/pull/10/commits/5a33f2f2cede845590d35c47de7a2a4e899b1ae9)