### PR TITLE
Potential fix for code scanning alert no. 12: Useless regular-expression character escape

### DIFF
--- a/scripts/generate-translations.js
+++ b/scripts/generate-translations.js
@@ -114,7 +114,7 @@ async function loadModuleTranslations() {
       if (sectionName === "osSwitch") sectionName = "osSwitch";
 
       const translationsMatch = content.match(
-        new RegExp(`export const ${varName}[\s\S]*?=\s*{([\s\S]*?)}\s*;`),
+        new RegExp(`export const ${varName}[\\s\\S]*?=\\s*{([\\s\\S]*?)}\\s*;`),
       );
       if (!translationsMatch) continue;
 
@@ -123,7 +123,7 @@ async function loadModuleTranslations() {
       for (const locale of SUPPORTED_LOCALES) {
         const localeMatch = translationsBlock.match(
           new RegExp(
-            `${locale}\s*:\s*{([\s\S]*?)}\s*,?\s*(?:${SUPPORTED_LOCALES.join("|")}|$)`,
+            `${locale}\\s*:\\s*{([\\s\\S]*?)}\\s*,?\\s*(?:${SUPPORTED_LOCALES.join("|")}|$)`,
           ),
         );
         if (!localeMatch) continue;


### PR DESCRIPTION
Potential fix for [https://github.com/BANSAFAn/xmcl-website-NOT-OFFICIAL-/security/code-scanning/12](https://github.com/BANSAFAn/xmcl-website-NOT-OFFICIAL-/security/code-scanning/12)

To fix this, double each backslash used in regex patterns constructed as strings, so the string literal itself contains two backslashes (e.g., `\\s`, `\\S`), ensuring that the regular expression gets a single escaped character as expected (i.e., `/\s/`, `/\S/`). Update line 117, changing `[\s\S]` to `[\\s\\S]` and other regexes as needed. Similarly, check the other regex strings being passed to `RegExp` elsewhere in the snippet (including line 126 and others if present) and double their backslashes. The fix consists of updating these literals in-place; no imports or further definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
